### PR TITLE
[Fixed]现在改变 Mercury 的前景色和背景色

### DIFF
--- a/assets/wgsl/noise/sphere_tex.wgsl
+++ b/assets/wgsl/noise/sphere_tex.wgsl
@@ -112,9 +112,9 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         simu_color = mix(vec3<f32>(0.101961,0.619608,0.666667),
                     vec3<f32>(0.666667,0.666667,0.498039), min(f*3.2, 1.0));
         simu_color = mix(simu_color,
-                    vec3<f32>(0., 0., 0.164706), min(length(q), 1.0));
+                    params.bg_color.rgb, min(length(q), 1.0));
         simu_color = mix(simu_color, 
-                    vec3<f32>(0.666667,1., 1.), min(length(r.x), 1.0));
+                    params.front_color.rgb, min(length(r.x), 1.0));
     }
 
     // Light

--- a/src/setting/noise_setting.rs
+++ b/src/setting/noise_setting.rs
@@ -41,8 +41,8 @@ impl NoiseSetting {
                 self.gain = 0.49;
             }
             Some(3) => {
-                self.back_color = [0.222, 0.261, 0.687];
-                self.front_color = [0.2, 0.698, 0.261];
+                self.back_color  = [0.000,0.000,0.165];
+                self.front_color = [0.667,1.000,1.000];
                 self.noise_scale = 1.5;
                 self.octave = 3;
                 self.lacunarity = 1.8;


### PR DESCRIPTION
在 Mercury 选项下，用户更改背景色和前景色 材质 无变化。
1. 修改了shader文件，使其使用背景色和前景色两个设置选项；
2. 修改了设置文件，使其默认设置和原来的shader文件保持一致；